### PR TITLE
fixed include/exclude bug

### DIFF
--- a/tests/unit/test_dataset_utils.py
+++ b/tests/unit/test_dataset_utils.py
@@ -1,6 +1,9 @@
 import pytest
+from collections import Counter
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import thoa.core.dataset_utils as dataset_utils
 from thoa.core.dataset_utils import (
     _filter_files_by_id_or_path,
     _fmt_bytes,
@@ -13,6 +16,9 @@ from thoa.core.dataset_utils import (
     _extract_url,
     _safe_dest,
     _build_tree,
+    _filtered_download_size,
+    _should_decrement_downloads,
+    download_dataset,
 )
 
 
@@ -203,3 +209,167 @@ class TestBuildTree:
 
     def test_empty(self):
         assert _build_tree({}) == {}
+
+
+class FakeClient:
+    """Minimal stand-in for api_client, routing by path prefix."""
+
+    def __init__(self, dataset, files=None):
+        self.dataset = dataset
+        self.files = files or []
+        self.get_calls = []
+        self.put_calls = []
+        self.post_calls = []
+
+    def get(self, path, **kwargs):
+        self.get_calls.append(path)
+        if path.startswith("/datasets?public_id="):
+            return [self.dataset]
+        if path.startswith("/files?dataset_public_id="):
+            return self.files
+        return None
+
+    def put(self, path, **kwargs):
+        self.put_calls.append(path)
+        return {}
+
+    def post(self, path, **kwargs):
+        self.post_calls.append(path)
+        return {"url": "https://example.com/fake-blob"}
+
+
+class TestFilteredDownloadSize:
+
+    def test_no_filter_returns_total_size_without_extra_lookup(self, monkeypatch):
+        fake_client = MagicMock()
+        monkeypatch.setattr(dataset_utils, "client", fake_client)
+
+        result = _filtered_download_size(
+            total_size=10_000,
+            files={"a.bam": "id1"},
+            include=None,
+            exclude=None,
+            dataset_id="ds1",
+        )
+
+        assert result == 10_000
+        fake_client.get.assert_not_called()
+
+    def test_filter_sums_only_matched_subset(self, monkeypatch):
+        fake = FakeClient(
+            dataset=None,
+            files=[
+                {"public_id": "id1", "size": 1_000},
+                {"public_id": "id2", "size": 34 * 1024**3},
+            ],
+        )
+        monkeypatch.setattr(dataset_utils, "client", fake)
+
+        result = _filtered_download_size(
+            total_size=34 * 1024**3 + 1_000,
+            files={"logs/hs_err_pid42.log": "id1"},  # only id1 survived the include filter
+            include=["*/hs_err_pid42.log"],
+            exclude=None,
+            dataset_id="ds1",
+        )
+
+        assert result == 1_000
+
+    def test_falls_back_to_total_size_when_sizes_unavailable(self, monkeypatch):
+        fake = FakeClient(dataset=None, files=[])
+        monkeypatch.setattr(dataset_utils, "client", fake)
+
+        result = _filtered_download_size(
+            total_size=5_000,
+            files={"a.bam": "id1"},
+            include=["*.bam"],
+            exclude=None,
+            dataset_id="ds1",
+        )
+
+        assert result == 5_000
+
+
+class TestShouldDecrementDownloads:
+
+    def test_false_when_nothing_succeeded(self):
+        assert _should_decrement_downloads(Counter({"failed": 2})) is False
+
+    def test_false_when_empty(self):
+        assert _should_decrement_downloads(Counter()) is False
+
+    def test_false_when_only_skipped(self):
+        # Files already present locally aren't a fresh transfer.
+        assert _should_decrement_downloads(Counter({"skipped": 2})) is False
+
+    def test_true_when_any_success(self):
+        assert _should_decrement_downloads(Counter({"success": 1, "failed": 3})) is True
+
+
+class TestDownloadDatasetQuotaGating:
+    """Integration-style tests: quota should only be consumed on actual transfer."""
+
+    @staticmethod
+    def _dataset(remaining=1, total_size=1000, context=None):
+        return {
+            "remaining_downloads": remaining,
+            "total_size": total_size,
+            "adjusted_context": context if context is not None else {"a.txt": "id1"},
+        }
+
+    def test_no_files_matched_filter_does_not_decrement(self, tmp_path, monkeypatch):
+        fake = FakeClient(dataset=self._dataset(context={"a.txt": "id1"}))
+        monkeypatch.setattr(dataset_utils, "client", fake)
+
+        download_dataset("ds1", str(tmp_path), include=["*.nomatch"])
+
+        assert fake.put_calls == []
+
+    def test_disk_space_failure_does_not_decrement(self, tmp_path, monkeypatch):
+        fake = FakeClient(dataset=self._dataset(total_size=10**12))
+        monkeypatch.setattr(dataset_utils, "client", fake)
+        monkeypatch.setattr(dataset_utils, "_available_bytes", lambda p: 0)
+
+        download_dataset("ds1", str(tmp_path))
+
+        assert fake.put_calls == []
+
+    def test_all_transfers_failed_does_not_decrement(self, tmp_path, monkeypatch):
+        fake = FakeClient(dataset=self._dataset())
+        monkeypatch.setattr(dataset_utils, "client", fake)
+        monkeypatch.setattr(dataset_utils, "_available_bytes", lambda p: 10**12)
+        monkeypatch.setattr(
+            dataset_utils,
+            "_download_one",
+            lambda path_string, file_id, link_info, base_dir, verify_md5, per_blob_concurrency, chunk_size: (
+                path_string, file_id, False, "error:boom",
+            ),
+        )
+
+        download_dataset("ds1", str(tmp_path))
+
+        assert fake.put_calls == []
+
+    def test_successful_transfer_decrements_once(self, tmp_path, monkeypatch):
+        fake = FakeClient(dataset=self._dataset())
+        monkeypatch.setattr(dataset_utils, "client", fake)
+        monkeypatch.setattr(dataset_utils, "_available_bytes", lambda p: 10**12)
+        monkeypatch.setattr(
+            dataset_utils,
+            "_download_one",
+            lambda path_string, file_id, link_info, base_dir, verify_md5, per_blob_concurrency, chunk_size: (
+                path_string, file_id, True, "downloaded",
+            ),
+        )
+
+        download_dataset("ds1", str(tmp_path))
+
+        assert fake.put_calls == ["/datasets/ds1/decrement_downloads"]
+
+    def test_zero_remaining_downloads_does_not_decrement(self, tmp_path, monkeypatch):
+        fake = FakeClient(dataset=self._dataset(remaining=0))
+        monkeypatch.setattr(dataset_utils, "client", fake)
+
+        download_dataset("ds1", str(tmp_path))
+
+        assert fake.put_calls == []

--- a/tests/unit/test_dataset_utils.py
+++ b/tests/unit/test_dataset_utils.py
@@ -289,6 +289,30 @@ class TestFilteredDownloadSize:
 
         assert result == 5_000
 
+    def test_falls_back_to_total_size_when_one_matched_file_has_no_size(self, monkeypatch):
+        # id1 has a real size; id2's size came back null from /files. A partial
+        # sum (3 GB + 0) would under-count the true ~5 GB and let the disk
+        # check pass when there isn't actually enough space, so this must
+        # fall back to the safe upper bound (total_size), not return 3 GB.
+        fake = FakeClient(
+            dataset=None,
+            files=[
+                {"public_id": "id1", "size": 3 * 1024**3},
+                {"public_id": "id2", "size": None},
+            ],
+        )
+        monkeypatch.setattr(dataset_utils, "client", fake)
+
+        result = _filtered_download_size(
+            total_size=9 * 1024**3,
+            files={"a.bam": "id1", "b.bam": "id2"},
+            include=["*.bam"],
+            exclude=None,
+            dataset_id="ds1",
+        )
+
+        assert result == 9 * 1024**3
+
 
 class TestShouldDecrementDownloads:
 

--- a/thoa/core/dataset_utils.py
+++ b/thoa/core/dataset_utils.py
@@ -105,11 +105,15 @@ def _required_with_headroom(total_size_bytes: int) -> int:
     headroom = max(int(total_size_bytes * 0.05), 200 * 1024 * 1024)
     return total_size_bytes + headroom
 
-def _fetch_file_size_map(dataset_id) -> dict[str, int]:
-    """Fetch {file_id: size} for every file in a dataset via GET /files."""
+def _fetch_file_size_map(dataset_id) -> dict[str, int | None]:
+    """Fetch {file_id: size} for every file in a dataset via GET /files.
+
+    A missing/null size comes through as None so callers can tell "unknown"
+    apart from a genuine 0-byte file, instead of silently treating both as 0.
+    """
     file_list = client.get(f"/files?dataset_public_id={dataset_id}") or []
     return {
-        str(f["public_id"]): int(f.get("size") or 0)
+        str(f["public_id"]): (int(f["size"]) if f.get("size") is not None else None)
         for f in file_list
         if f.get("public_id") is not None
     }
@@ -123,17 +127,16 @@ def _filtered_download_size(
 ) -> int:
     """Size to actually validate/display for the (already-filtered) file set.
 
-    Without a filter, the whole-dataset total_size is accurate. With one,
-    total_size no longer reflects what will be downloaded, so sum per-file
-    sizes for just the filtered subset, falling back to total_size if sizes
-    can't be determined.
+    Without a filter, the whole-dataset total_size is accurate. With one, sum
+    per-file sizes for just the filtered subset -- but only if every matched
+    file has a known size.
     """
     if not include and not exclude:
         return total_size
 
     size_map = _fetch_file_size_map(dataset_id)
-    filtered_total = sum(size_map.get(str(fid), 0) for fid in files.values())
-    return filtered_total if filtered_total > 0 else total_size
+    sizes = [size_map.get(str(fid)) for fid in files.values()]
+    return sum(sizes) if sizes and all(sizes) else total_size
 
 def _should_decrement_downloads(outcome_counts: Counter) -> bool:
     """Only consume a download once at least one file was actually transferred."""

--- a/thoa/core/dataset_utils.py
+++ b/thoa/core/dataset_utils.py
@@ -105,6 +105,40 @@ def _required_with_headroom(total_size_bytes: int) -> int:
     headroom = max(int(total_size_bytes * 0.05), 200 * 1024 * 1024)
     return total_size_bytes + headroom
 
+def _fetch_file_size_map(dataset_id) -> dict[str, int]:
+    """Fetch {file_id: size} for every file in a dataset via GET /files."""
+    file_list = client.get(f"/files?dataset_public_id={dataset_id}") or []
+    return {
+        str(f["public_id"]): int(f.get("size") or 0)
+        for f in file_list
+        if f.get("public_id") is not None
+    }
+
+def _filtered_download_size(
+    total_size: int,
+    files: dict[str, str],
+    include: list[str] | None,
+    exclude: list[str] | None,
+    dataset_id,
+) -> int:
+    """Size to actually validate/display for the (already-filtered) file set.
+
+    Without a filter, the whole-dataset total_size is accurate. With one,
+    total_size no longer reflects what will be downloaded, so sum per-file
+    sizes for just the filtered subset, falling back to total_size if sizes
+    can't be determined.
+    """
+    if not include and not exclude:
+        return total_size
+
+    size_map = _fetch_file_size_map(dataset_id)
+    filtered_total = sum(size_map.get(str(fid), 0) for fid in files.values())
+    return filtered_total if filtered_total > 0 else total_size
+
+def _should_decrement_downloads(outcome_counts: Counter) -> bool:
+    """Only consume a download once at least one file was actually transferred."""
+    return outcome_counts.get("success", 0) > 0
+
 
 def _format_timestamp(ts: str) -> str:
     """Convert ISO timestamp to 'Mon DD YYYY, HH:MM' format."""
@@ -293,16 +327,7 @@ def download_dataset(
             dataset = datasets[0]
             downloads_remaining = dataset.get("remaining_downloads")
 
-            if downloads_remaining > 0:
-                client.put(f"/datasets/{dataset_id}/decrement_downloads")
-                console.print(
-                    Panel(
-                        f"[green]Dataset {dataset_id} has {downloads_remaining - 1} downloads remaining.[/green]",
-                        title="Download Count",
-                        style="bold green",
-                    )
-                )
-            else:
+            if not downloads_remaining or downloads_remaining <= 0:
                 console.print(
                     Panel(
                         f"[yellow]Dataset {dataset_id} has no remaining downloads.[/yellow]",
@@ -313,7 +338,6 @@ def download_dataset(
                 return
 
             total_size = int(dataset.get("total_size", 0) or 0)
-            dgb = round(total_size / 1024**3, 2)
 
             files = dataset.get("adjusted_context", {})
             if not files:
@@ -338,10 +362,13 @@ def download_dataset(
                 )
                 return
 
+            dl_size = _filtered_download_size(total_size, files, include, exclude, dataset_id)
+            dgb = round(dl_size / 1024**3, 2)
+
             target = Path(destination_path).expanduser()
             avail = _available_bytes(target)
-            required = _required_with_headroom(total_size) if total_size > 0 else None
-            if total_size > 0 and avail < required:
+            required = _required_with_headroom(dl_size) if dl_size > 0 else None
+            if dl_size > 0 and avail < required:
                 missing = required - avail
                 console.print(
                     Panel(
@@ -435,6 +462,24 @@ def download_dataset(
             console.print(
                 Panel(f"[red]{note}[/red]\n{p}", title="File failed", style="bold red")
             )
+
+    if _should_decrement_downloads(outcome_counts):
+        client.put(f"/datasets/{dataset_id}/decrement_downloads")
+        console.print(
+            Panel(
+                f"[green]Dataset {dataset_id} has {downloads_remaining - 1} downloads remaining.[/green]",
+                title="Download Count",
+                style="bold green",
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                "[yellow]No download was consumed (no files were successfully transferred).[/yellow]",
+                title="Download Count",
+                style="bold yellow",
+            )
+        )
 
     console.print(
         Panel(


### PR DESCRIPTION
Fixes #146: the disk-space check now sizes only the --include/--exclude-filtered file set instead of the whole dataset, and download quota is only decremented after a file successfully transfers (not on failed/empty attempts).